### PR TITLE
Update contribute.qmd

### DIFF
--- a/docs/contribute.qmd
+++ b/docs/contribute.qmd
@@ -49,10 +49,10 @@ Under the `contents:` object add a new section (if required), a string lable for
 Remember to [render your changes locally using R-Studio](https://quarto.org/docs/tools/rstudio.html#render-and-preview) before publishing
 :::
 
-Commit your changes locally
+Add all changes and commit locally
 
 ```bash
-git commit -m 'Added new page to docs'
+git commit -a -m 'Added new page to docs'
 ```
 
 Then push your changes to the remote branch


### PR DESCRIPTION
The current bash command for committing to git won't do anything because the reader isn't instructed to `git add` first. This can be done with `git add .`, `git add <filename>`, or `git commit -a -m "Commit message"`, so I picked the latter for simplicity